### PR TITLE
PXP-2161 fix color typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Basic UI component for gen3",
   "main": "index.js",
   "scripts": {

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -23,14 +23,14 @@
   --g3-primary-btn__bg-color--hover: var(--g3-color__highlight-orange-light);
   --g3-primary-btn__border-color: var(--g3-color__lightgray);
   --g3-primary-btn__border-color--hover: var(--g3-color__gray);
-  --g3-primary-btn__border-color--active: var(--g3-color__light-gray);
+  --g3-primary-btn__border-color--active: var(--g3-color__lightgray);
 
   --g3-secondary-btn__color: var(--g3-color__white);
   --g3-secondary-btn__bg-color: var(--g3-color__base-blue);
   --g3-secondary-btn__bg-color--hover: var(--g3-color__base-blue-light);
   --g3-secondary-btn__border-color: var(--g3-color__lightgray);
   --g3-secondary-btn__border-color--hover: var(--g3-color__gray);
-  --g3-secondary-btn__border-color--active: var(--g3-color__light-gray);
+  --g3-secondary-btn__border-color--active: var(--g3-color__lightgray);
 
   --g3-default-btn__color: var(--g3-color__gray);
   --g3-default-btn__color--hover: var(--g3-color__black);


### PR DESCRIPTION
The buttons in our UI library were changing size on click due to a typo in the color variable name - with this change they don't change size.