### PR TITLE
fix(edge): fix icon and charts strange behavior in Microsoft Edge

### DIFF
--- a/src/components/Dropdown/DropdownButton.css
+++ b/src/components/Dropdown/DropdownButton.css
@@ -24,7 +24,7 @@
 
 .g3-dropdown-button__icon {
   display: inline-block;
-  mask-size: contain;
+  mask-size: 100% 100%;
   mask-repeat: no-repeat;
   width: 12px;
   height: 12px;
@@ -35,7 +35,7 @@
   width: 18px;
   height: 18px;
   background-color: white;
-  mask-size: contain;
+  mask-size: 100% 100%;
   mask-repeat: no-repeat;
   mask-image: svg-load(../../images/icons/more.svg);
   position: absolute;

--- a/src/components/charts/SummaryHorizontalBarChart/SummaryHorizontalBarChart.css
+++ b/src/components/charts/SummaryHorizontalBarChart/SummaryHorizontalBarChart.css
@@ -21,7 +21,7 @@
 
 .summary-horizontal-bar-chart__item-label {
   white-space: nowrap;
-  overflow-x: hidden;
+  overflow: hidden;
   text-overflow: ellipsis;
   font-size: 14px;
   font-weight: normal;

--- a/src/components/charts/SummaryPieChart/SummaryPieChart.css
+++ b/src/components/charts/SummaryPieChart/SummaryPieChart.css
@@ -43,7 +43,7 @@
 
 .summary-pie-chart__legend-item-name {
   white-space: nowrap;
-  overflow-x: hidden;
+  overflow: hidden;
   text-overflow: ellipsis;
 }
 

--- a/src/css/icon.css
+++ b/src/css/icon.css
@@ -4,7 +4,7 @@
   display: inline-block;
   width: 18px;
   height: 18px;
-  mask-size: contain;
+  mask-size: 100% 100%;
   mask-repeat: no-repeat;
 }
 


### PR DESCRIPTION
 - The pie/bin charts' label names have a strange scroller. This PR removes it. 
 - Icons look strange in Edge browser, changing the `mask-size` attr will fix this. 