### PR TITLE
Add accessible focus outlines to components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Basic UI component for gen3",
   "main": "index.js",
   "scripts": {

--- a/src/components/AutoComplete/AutoCompleteInput.css
+++ b/src/components/AutoComplete/AutoCompleteInput.css
@@ -7,7 +7,6 @@
 }
 
 .auto-complete-input__input-box {
-  outline: none;
   border: none;
   width: 100%;
 }

--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -11,7 +11,6 @@
   height: 40px;
   font-size: 14px;
   cursor: pointer;
-  outline: none;
   font-weight: 600;
   padding: 1px 20px;
 }

--- a/src/components/Dropdown/Dropdown.css
+++ b/src/components/Dropdown/Dropdown.css
@@ -29,7 +29,6 @@
   vertical-align: middle;
   text-align: center;
   cursor: pointer;
-  outline: none;
   padding: 1px 0;
   margin: 0;
   position: relative;
@@ -102,5 +101,5 @@
 
 .g3-dropdown--secondary .g3-dropdown__item:hover,
 .g3-dropdown--secondary .g3-dropdown__item:active {
-  background-color: var(--g3-secondary-btn__bg-color--hover);  
+  background-color: var(--g3-secondary-btn__bg-color--hover);
 }

--- a/src/components/Dropdown/DropdownButton.css
+++ b/src/components/Dropdown/DropdownButton.css
@@ -13,7 +13,6 @@
   display: inline-block;
   vertical-align: middle;
   cursor: pointer;
-  outline: none;
   padding: 1px 30px 1px 20px;
   margin: 0;
   position: relative;
@@ -140,7 +139,6 @@
   border-radius: 0 4px 4px 0;
   vertical-align: middle;
   cursor: pointer;
-  outline: none;
   margin: 0;
   border-left: none;
   width: 30px;

--- a/src/components/TopBar/TopBarButton.css
+++ b/src/components/TopBar/TopBarButton.css
@@ -6,7 +6,6 @@
   width: auto;
   display: flex;
   align-items: baseline;
-  outline: none;
 }
 
 .top-bar-button--active, .top-bar-button:hover {

--- a/src/components/filters/FilterGroup/FilterGroup.css
+++ b/src/components/filters/FilterGroup/FilterGroup.css
@@ -20,7 +20,6 @@
   border: 1px solid var(--g3-color__silver);
   border-radius: 12px 12px 0 0;
   background-color: var(--g3-color__silver);
-  outline: none;
   cursor: pointer;
   font-size: 14px;
   font-weight: var(--g3-font__semi-bold-weight);
@@ -66,7 +65,6 @@
   padding: 0 10px;
   border-right: 1px solid var(--g3-color__silver);
   font-size: 14px;
-  outline: none;
 }
 
 .g3-filter-group__collapse-link:last-child {

--- a/src/components/filters/FilterSection/FilterSection.css
+++ b/src/components/filters/FilterSection/FilterSection.css
@@ -34,7 +34,6 @@
   flex-grow: 1;
   display: flex;
   align-items: center;
-  outline: none;
   cursor: pointer;
 }
 
@@ -81,13 +80,11 @@
 .g3-filter-section__search-icon {
   background-color: var(--g3-color__gray);
   margin-left: 10px;
-  outline: none;
   cursor: pointer;
 }
 
 .g3-filter-section__show-more {
   border: none;
-  outline: none;
   color: var(--g3-color__base-blue);
   cursor: pointer;
   margin-top: 15px;
@@ -116,7 +113,6 @@
 }
 
 .g3-filter-section__search-input-box {
-  outline: none;
   border: none;
   width: 100%;
 }
@@ -136,6 +132,15 @@
   top: 6px;
   right: 6px;
   background-color: var(--g3-color__gray);
+  cursor: pointer;
+}
+
+.g3-filter-section__search-input-spinner {
+  width: 20px;
+  height: 10px;
+  position: relative;
+  top: 10px;
+  right: 6px;
   cursor: pointer;
 }
 

--- a/src/components/filters/RangeFilter/RangeFilter.css
+++ b/src/components/filters/RangeFilter/RangeFilter.css
@@ -26,7 +26,6 @@
   border-radius: 0;
   width: 10px;
   border: 1px solid var(--g3-color__lightgray);
-  outline: none;
 }
 
 .rc-slider-handle:hover {


### PR DESCRIPTION
Adds focus outlines to all elements that were missing them, which is necessary to allow users to navigate components using just the keyboard. (See https://a11yproject.com/posts/never-remove-css-outlines/)

### Improvements
- Revert removal of focus outlines on all elements, necessary for accessibility / 508 compliance.

