### PR TITLE
(PXP-5837) Fix bug: clicking reset filter button does not update Guppy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Basic UI component for gen3",
   "main": "index.js",
   "scripts": {

--- a/src/components/filters/FilterGroup/index.jsx
+++ b/src/components/filters/FilterGroup/index.jsx
@@ -103,11 +103,23 @@ class FilterGroup extends React.Component {
 
   handleSectionClear(tabIndex, sectionIndex) {
     this.setState((prevState) => {
+      // update filter status
       const newFilterStatus = prevState.filterStatus.slice(0);
       newFilterStatus[tabIndex][sectionIndex] = {};
+
+      // update filter results; clear the results for this filter
+      let newFilterResults = prevState.filterResults;
+      const field = this.props.filterConfig.tabs[tabIndex].fields[sectionIndex];
+      newFilterResults[field] = {};
+      newFilterResults = removeEmptyFilter(newFilterResults);
+
+      // update component state
       return {
         filterStatus: newFilterStatus,
+        filterResults: newFilterResults,
       };
+    }, () => {
+      this.callOnFilterChange();
     });
   }
 

--- a/src/components/filters/FilterGroup/index.jsx
+++ b/src/components/filters/FilterGroup/index.jsx
@@ -108,7 +108,7 @@ class FilterGroup extends React.Component {
       newFilterStatus[tabIndex][sectionIndex] = {};
 
       // update filter results; clear the results for this filter
-      let newFilterResults = prevState.filterResults;
+      let newFilterResults = Object.assign({}, prevState.filterResults);
       const field = this.props.filterConfig.tabs[tabIndex].fields[sectionIndex];
       newFilterResults[field] = {};
       newFilterResults = removeEmptyFilter(newFilterResults);


### PR DESCRIPTION
Jira Ticket: [PXP-5837](https://ctds-planx.atlassian.net/browse/PXP-5837)

Before this fix, when the 'reset' button was clicked, the visual state of the filters was updated on the explorer page but the FilterGroup component did not kick off a new request to Guppy. 
Fix: call FilterGroup's props.onFilterChange when filters are reset

### Bug Fixes
- Fixed a critical bug that prevented filter 'Reset' buttons from working in Windmill.

