### PR TITLE
fix(no-extraneous-dependencies): disable eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "prepare": "rm -rf dist && npm run eslint && npm run stylelint && npx gulp",
     "prepare-dev": "rm -rf dist && npm run eslint && npm run stylelint && npx gulp --dev",
-    "eslint": "eslint --ext js --ext jsx --ignore-pattern '**/setupTests.js' --ignore-pattern 'dist/' --fix src",
+    "eslint": "eslint --ext js --ext jsx --ignore-pattern 'dist/' --fix src",
     "stylelint": "stylelint 'src/**/*.less' 'src/**/*.css' 'stories/*.css' --config .stylelintrc.js --fix"
   },
   "repository": {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 const Enzyme = require('enzyme');
 const EnzymeAdapter = require('enzyme-adapter-react-16');
 


### PR DESCRIPTION
This PR fixes the `import/no-extraneous-dependencies` ESLint error for devDependencies (`enzyme` and `enzyme-adapter-react-16`) when running `eslint` npm script, which somehow keeps occurring despite the `--ignore-pattern` flag targeting `src/setupTests.js`.

### Bug Fixes
* Replace the `--ignore-pattern` flag in `eslint` script with a more direct approach of adding a comment `/* eslint-disable import/no-extraneous-dependencies */` in the `src/setupTests.js` file.
