### PR TITLE
Fix/pie chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Basic UI component for gen3",
   "main": "index.js",
   "scripts": {

--- a/src/components/charts/SummaryPieChart/index.jsx
+++ b/src/components/charts/SummaryPieChart/index.jsx
@@ -59,8 +59,11 @@ class SummaryPieChart extends React.Component {
                         <span className='summary-pie-chart__legend-item-value-number'>
                           { helper.numberWithCommas(entry.value) }
                         </span>
+                        <br />
                         <span className='summary-pie-chart__legend-item-value-percentage'>
+                          (
                           { helper.percentageFormatter(this.props.showPercentage)(entry[dataKey]) }
+                          )
                         </span>
                       </div>
                     </div>


### PR DESCRIPTION
Fixed a bug for pie chart introduced by https://github.com/uc-cdis/gen3-ui-component/pull/72/commits/890de4cb62d5b015240e2918df46ecdf45c91bf8

I was confused by the linter and remove some good code 🤦 

Updated the pie chart so the actual count and percentage would be displayed in separate lines since the count might get huge

<img width="418" alt="Screen Shot 2020-07-07 at 1 15 25 PM" src="https://user-images.githubusercontent.com/2475897/86824976-77ec9280-c054-11ea-931b-c0894f4350e7.png">


### Bug Fixes
- Fixed a bug that causing pie chart to display incorrectly counts and percentages
