### PR TITLE
Fix css bug in single select filter when using portal 2.32.2

### DIFF
--- a/src/components/filters/SingleSelectFilter/SingleSelectFilter.css
+++ b/src/components/filters/SingleSelectFilter/SingleSelectFilter.css
@@ -39,6 +39,7 @@
   height: 40%;
   border: solid var(--g3-color__white);
   border-width: 0 2px 2px 0;
+  box-sizing: initial;
   transform: rotate(45deg);
   display: none;
 }


### PR DESCRIPTION
Portal 2.32.2 introduces Ant design which sets `box-sizing` to `border-box` on all elements. This causes a visual bug in the checkmark icon in SingleSelectFilters, which this commit fixes by manually resetting `box-sizing` to `initial` on the checkmark icon.
 
### New Features


### Breaking Changes


### Bug Fixes
- Fixes a UI bug which causes the checkbox icon in a SingleSelectFilter to appear distorted if using Portal >= 2.32.2

### Improvements


### Dependency updates


### Deployment changes

