### PR TITLE
(PXP-6221): feat/comma-numbers: filters and charts updated helper function refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Basic UI component for gen3",
   "main": "index.js",
   "scripts": {

--- a/src/components/charts/SummaryHorizontalBarChart/index.jsx
+++ b/src/components/charts/SummaryHorizontalBarChart/index.jsx
@@ -87,7 +87,7 @@ class SummaryBarChart extends React.Component {
                       role='button'
                       tabIndex={0}
                     >
-                      {`And ${barChartData.length - this.props.maximumDisplayItem} more`}
+                      {`And ${(barChartData.length - this.props.maximumDisplayItem).toLocaleString()} more`}
                     </div>
                   )
                 }

--- a/src/components/charts/SummaryPieChart/index.jsx
+++ b/src/components/charts/SummaryPieChart/index.jsx
@@ -57,7 +57,7 @@ class SummaryPieChart extends React.Component {
                       </div>
                       <div className='summary-pie-chart__legend-item-value form-special-number'>
                         <span className='summary-pie-chart__legend-item-value-number'>
-                          { helper.numberWithCommas(entry.value) }
+                          { Number(entry.value).toLocaleString() }
                         </span>
                         <br />
                         <span className='summary-pie-chart__legend-item-value-percentage'>
@@ -94,7 +94,7 @@ class SummaryPieChart extends React.Component {
                         role='button'
                         tabIndex={0}
                       >
-                        {`And ${pieChartData.length - this.props.maximumDisplayItem} more`}
+                        {`And ${(pieChartData.length - this.props.maximumDisplayItem).toLocaleString()} more`}
                       </div>
                     )
                   }

--- a/src/components/charts/helper.js
+++ b/src/components/charts/helper.js
@@ -1,7 +1,5 @@
 const percentageFormatter = showPercentage => v => (showPercentage ? `${v}%` : v);
 
-const numberWithCommas = x => x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-
 const addPercentage = v => (percentageFormatter(true)(v));
 
 const calculateChartData = (data, percentageFixedPoint) => {
@@ -150,7 +148,6 @@ const shouldHideChart = (data, lockValue) => data.find(item => item.value === lo
 
 const helper = {
   percentageFormatter,
-  numberWithCommas,
   addPercentage,
   calculateChartData,
   getPercentageData,

--- a/src/components/filters/FilterSection/index.jsx
+++ b/src/components/filters/FilterSection/index.jsx
@@ -165,7 +165,7 @@ class FilterSection extends React.Component {
             onKeyPress={() => this.toggleShowMore()}
             tabIndex={0}
           >
-            {moreCount}
+            {moreCount.toLocaleString()}
             &nbsp;more
           </div>
         );

--- a/src/components/filters/SingleSelectFilter/index.jsx
+++ b/src/components/filters/SingleSelectFilter/index.jsx
@@ -53,7 +53,7 @@ class SingleSelectFilter extends React.Component {
       inputDisabled = !selected;
       countIconComponent = this.props.tierAccessLimit ? (
         <span className='g3-badge g3-single-select-filter__count'>
-          {this.props.tierAccessLimit}
+          {Number(this.props.tierAccessLimit).toLocaleString()}
           <i className='g3-icon--under g3-icon g3-icon--sm g3-icon-color__base-blue' />
         </span>
       ) : (
@@ -79,7 +79,7 @@ class SingleSelectFilter extends React.Component {
         );
       }
     } else if (this.props.accessible) {
-      countIconComponent = <span className='g3-badge g3-single-select-filter__count'>{this.props.count}</span>;
+      countIconComponent = <span className='g3-badge g3-single-select-filter__count'>{Number(this.props.count).toLocaleString()}</span>;
     }
 
     return (

--- a/stories/charts.js
+++ b/stories/charts.js
@@ -37,12 +37,22 @@ const speciesData = [
   { name: 'spicies3', value: 300 },
 ];
 
+const bigSet = [];
+const NUM_OPTIONS = 2000;
+for (let i = 0; i < NUM_OPTIONS; i += 1) {
+  bigSet.push({
+    name: `item-${i}`,
+    value: Math.random()
+  });
+}
+
 const summaries = [
   { type: 'bar', title: 'Gender', data: genderData },
   { type: 'pie', title: 'Birth-Year', data: birthData },
   { type: 'pie', title: 'Species', data: speciesData },
   { type: 'bar', title: 'Race', data: raceData },
   { type: 'bar', title: 'Virus', data: virusData },
+  { type: 'bar', title: 'Big Set', data: bigSet },
 ];
 
 const lockedVirus = [

--- a/stories/filters.js
+++ b/stories/filters.js
@@ -8,6 +8,7 @@ import FilterList from '../src/components/filters/FilterList';
 import FilterGroup from '../src/components/filters/FilterGroup';
 
 const projectOptions = [
+  { text: 'big-number', filterType: 'singleSelect', count: 123456789 },
   { text: 'ndh-CHARLIE', filterType: 'singleSelect', count: 123 },
   { text: 'ndh-dait-microbiome', filterType: 'singleSelect', count: 123 },
   { text: 'ndh-dmid-LMV', filterType: 'singleSelect', count: 123 },
@@ -111,6 +112,7 @@ const subjectSections = [
   { title: 'Race', options: raceOptions },
   { title: 'Ethnicity', options: ethnicityOptions },
   { title: 'Age', options: ageOptions },
+  { title: 'Big List', options: guidOptions },
 ];
 
 const fileSections = [
@@ -181,6 +183,9 @@ storiesOf('Filters', module)
       <SingleSelectFilter label='Option3' onSelect={action('checked')} count={-1} accessible tierAccessLimit={1000} />
       <SingleSelectFilter label='Option4' onSelect={action('checked')} count={4} accessible={false} />
       <SingleSelectFilter label='Option5' onSelect={action('checked')} count={-1} accessible={false} tierAccessLimit={1000} />
+      <SingleSelectFilter label='Option6' onSelect={action('checked')} count={123456789} accessible />
+      <SingleSelectFilter label='Option7' onSelect={action('checked')} count={-1} accessible tierAccessLimit={123456789} />
+      <SingleSelectFilter label='Option8' onSelect={action('checked')} count={123456789} accessible={false} />
     </div>
   ))
   .add('RangeFilter', () => (
@@ -197,6 +202,13 @@ storiesOf('Filters', module)
         min={0.00000000001}
         max={99.9999999999}
         rangeStep={0.1}
+      />
+      <RangeFilter
+        label='Range slider Big Numbers'
+        onAfterDrag={action('range change')}
+        min={0}
+        max={2000000}
+        rangeStep={10}
       />
     </div>
   ))


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features
Added commas in numbers in the explorer for:
- in filters: the number of rows for each value
- in filters: “and X more”
- in charts: “and X more”

Added several big number examples to the storybook

### Improvements
Refactored old comma adding to use built in js function


