### PR TITLE
PXP-7378 Feat/full pie

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,10 +14,6 @@ module.exports = {
         "react"
     ],
     "rules": {
-        "indent": [
-            "error",
-            2
-        ],
         "linebreak-style": [
             "error",
             "unix"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Basic UI component for gen3",
   "main": "index.js",
   "scripts": {

--- a/src/components/charts/SummaryChartGroup/index.jsx
+++ b/src/components/charts/SummaryChartGroup/index.jsx
@@ -6,7 +6,7 @@ import './SummaryChartGroup.css';
 import helper from '../helper.js';
 
 class SummaryChartGroup extends Component {
-  getChart = (item) => {
+  getChart(item) {
     switch (item.type) {
     case 'pie':
       return (

--- a/src/components/charts/SummaryChartGroup/index.jsx
+++ b/src/components/charts/SummaryChartGroup/index.jsx
@@ -8,8 +8,8 @@ import helper from '../helper.js';
 class SummaryChartGroup extends Component {
   getChart(item) {
     switch (item.type) {
-    case 'pie':
-      return (
+      case 'pie':
+        return (
         <SummaryPieChart
           data={item.data}
           title={item.title}
@@ -21,9 +21,9 @@ class SummaryChartGroup extends Component {
           chartIsEmpty={item.chartIsEmpty}
           chartEmptyMessage={this.props.chartEmptyMessage}
         />
-      );
-    case 'full-pie':
-      return (
+        );
+      case 'full-pie':
+        return (
         <SummaryPieChart
           data={item.data}
           title={item.title}
@@ -36,9 +36,9 @@ class SummaryChartGroup extends Component {
           chartEmptyMessage={this.props.chartEmptyMessage}
           innerRadius={0}
         />
-      );
-    case 'bar':
-      return (
+        );
+      case 'bar':
+        return (
         <SummaryHorizontalBarChart
           data={item.data}
           title={item.title}
@@ -53,9 +53,9 @@ class SummaryChartGroup extends Component {
           chartIsEmpty={item.chartIsEmpty}
           chartEmptyMessage={this.props.chartEmptyMessage}
         />
-      );
-    default:
-      return null;
+        );
+      default:
+        return null;
     }
   }
 

--- a/src/components/charts/SummaryChartGroup/index.jsx
+++ b/src/components/charts/SummaryChartGroup/index.jsx
@@ -22,7 +22,7 @@ class SummaryChartGroup extends Component {
           chartEmptyMessage={this.props.chartEmptyMessage}
         />
         );
-      case 'full-pie':
+      case 'fullPie':
         return (
         <SummaryPieChart
           data={item.data}

--- a/src/components/charts/SummaryChartGroup/index.jsx
+++ b/src/components/charts/SummaryChartGroup/index.jsx
@@ -6,6 +6,59 @@ import './SummaryChartGroup.css';
 import helper from '../helper.js';
 
 class SummaryChartGroup extends Component {
+  getChart = (item) => {
+    switch (item.type) {
+    case 'pie':
+      return (
+        <SummaryPieChart
+          data={item.data}
+          title={item.title}
+          lockValue={this.props.lockValue}
+          lockMessage={this.props.lockMessage}
+          useCustomizedColorMap={this.props.useCustomizedColorMap}
+          customizedColorMap={this.props.customizedColorMap}
+          maximumDisplayItem={this.props.maximumDisplayItem}
+          chartIsEmpty={item.chartIsEmpty}
+          chartEmptyMessage={this.props.chartEmptyMessage}
+        />
+      );
+    case 'full-pie':
+      return (
+        <SummaryPieChart
+          data={item.data}
+          title={item.title}
+          lockValue={this.props.lockValue}
+          lockMessage={this.props.lockMessage}
+          useCustomizedColorMap={this.props.useCustomizedColorMap}
+          customizedColorMap={this.props.customizedColorMap}
+          maximumDisplayItem={this.props.maximumDisplayItem}
+          chartIsEmpty={item.chartIsEmpty}
+          chartEmptyMessage={this.props.chartEmptyMessage}
+          innerRadius={0}
+        />
+      );
+    case 'bar':
+      return (
+        <SummaryHorizontalBarChart
+          data={item.data}
+          title={item.title}
+          vertical
+          color={this.props.useCustomizedColorMap ? undefined
+            : this.props.barChartColor}
+          lockValue={this.props.lockValue}
+          lockMessage={this.props.lockMessage}
+          useCustomizedColorMap={this.props.useCustomizedColorMap}
+          customizedColorMap={this.props.customizedColorMap}
+          maximumDisplayItem={this.props.maximumDisplayItem}
+          chartIsEmpty={item.chartIsEmpty}
+          chartEmptyMessage={this.props.chartEmptyMessage}
+        />
+      );
+    default:
+      return null;
+    }
+  }
+
   render() {
     const width = helper.parseParamWidth(this.props.width);
     return (
@@ -16,37 +69,7 @@ class SummaryChartGroup extends Component {
               {
                 index > 0 && <div className='summary-chart-group__column-left-border' />
               }
-              {
-                item.type === 'pie'
-                  ? (
-                    <SummaryPieChart
-                      data={item.data}
-                      title={item.title}
-                      lockValue={this.props.lockValue}
-                      lockMessage={this.props.lockMessage}
-                      useCustomizedColorMap={this.props.useCustomizedColorMap}
-                      customizedColorMap={this.props.customizedColorMap}
-                      maximumDisplayItem={this.props.maximumDisplayItem}
-                      chartIsEmpty={item.chartIsEmpty}
-                      chartEmptyMessage={this.props.chartEmptyMessage}
-                    />
-                  ) : (
-                    <SummaryHorizontalBarChart
-                      data={item.data}
-                      title={item.title}
-                      vertical
-                      color={this.props.useCustomizedColorMap ? undefined
-                        : this.props.barChartColor}
-                      lockValue={this.props.lockValue}
-                      lockMessage={this.props.lockMessage}
-                      useCustomizedColorMap={this.props.useCustomizedColorMap}
-                      customizedColorMap={this.props.customizedColorMap}
-                      maximumDisplayItem={this.props.maximumDisplayItem}
-                      chartIsEmpty={item.chartIsEmpty}
-                      chartEmptyMessage={this.props.chartEmptyMessage}
-                    />
-                  )
-              }
+              { this.getChart(item) }
             </div>
           ))
         }

--- a/src/components/charts/helper.js
+++ b/src/components/charts/helper.js
@@ -111,30 +111,30 @@ const getCharts = (data, dataExplorerConfig, sqon) => {
       const sqonValues = getSQONValues(sqon, field);
       if (fieldConfig) {
         switch (fieldConfig.chartType) {
-        case 'count':
-          countItems.push(transformDataToCount(fields[field], fieldConfig.title, sqonValues));
-          break;
-        case 'pie':
-        case 'bar':
-          summaries.push(
-            transformArrangerDataToSummary(
-              fields[field],
-              fieldConfig.chartType,
-              fieldConfig.title,
-              sqonValues),
-          );
-          break;
-        case 'stackedBar':
-          stackedBarCharts.push(
-            transformArrangerDataToSummary(
-              fields[field],
-              fieldConfig.chartType,
-              fieldConfig.title,
-              sqonValues),
-          );
-          break;
-        default:
-          break;
+          case 'count':
+            countItems.push(transformDataToCount(fields[field], fieldConfig.title, sqonValues));
+            break;
+          case 'pie':
+          case 'bar':
+            summaries.push(
+              transformArrangerDataToSummary(
+                fields[field],
+                fieldConfig.chartType,
+                fieldConfig.title,
+                sqonValues),
+            );
+            break;
+          case 'stackedBar':
+            stackedBarCharts.push(
+              transformArrangerDataToSummary(
+                fields[field],
+                fieldConfig.chartType,
+                fieldConfig.title,
+                sqonValues),
+            );
+            break;
+          default:
+            break;
         }
       }
     });

--- a/stories/charts.js
+++ b/stories/charts.js
@@ -49,7 +49,7 @@ for (let i = 0; i < NUM_OPTIONS; i += 1) {
 const summaries = [
   { type: 'bar', title: 'Gender', data: genderData },
   { type: 'pie', title: 'Birth-Year', data: birthData },
-  { type: 'full-pie', title: 'Species', data: speciesData },
+  { type: 'fullPie', title: 'Species', data: speciesData },
   { type: 'bar', title: 'Race', data: raceData },
   { type: 'bar', title: 'Virus', data: virusData },
   { type: 'bar', title: 'Big Set', data: bigSet },

--- a/stories/charts.js
+++ b/stories/charts.js
@@ -42,7 +42,7 @@ const NUM_OPTIONS = 2000;
 for (let i = 0; i < NUM_OPTIONS; i += 1) {
   bigSet.push({
     name: `item-${i}`,
-    value: Math.random()
+    value: Math.random(),
   });
 }
 
@@ -79,7 +79,9 @@ const lockedSummaries = [
 ];
 
 const summariesWithOneEmpty = [
-  { type: 'bar', title: 'Gender', data: genderData, chartIsEmpty: true },
+  {
+    type: 'bar', title: 'Gender', data: genderData, chartIsEmpty: true,
+  },
   { type: 'pie', title: 'Birth-Year', data: lockedBirth },
   { type: 'pie', title: 'Species', data: speciesData },
   { type: 'bar', title: 'Race', data: raceData },

--- a/stories/charts.js
+++ b/stories/charts.js
@@ -49,7 +49,7 @@ for (let i = 0; i < NUM_OPTIONS; i += 1) {
 const summaries = [
   { type: 'bar', title: 'Gender', data: genderData },
   { type: 'pie', title: 'Birth-Year', data: birthData },
-  { type: 'pie', title: 'Species', data: speciesData },
+  { type: 'full-pie', title: 'Species', data: speciesData },
   { type: 'bar', title: 'Race', data: raceData },
   { type: 'bar', title: 'Virus', data: virusData },
   { type: 'bar', title: 'Big Set', data: bigSet },
@@ -113,6 +113,9 @@ storiesOf('Chart', module)
   ))
   .add('SummaryPieChart with customized colors', () => (
     <SummaryPieChart data={virusData} title='pie chart title' showPercentage useCustomizedColorMap customizedColorMap={customizedColorMap} />
+  ))
+  .add('SummaryFullPieChart', () => (
+    <SummaryPieChart data={virusData} title='pie chart title' innerRadius={0} showPercentage />
   ))
   .add('SummaryChartGroup', () => (
     <SummaryChartGroup summaries={summaries} width={1010} />

--- a/stories/filters.js
+++ b/stories/filters.js
@@ -229,7 +229,7 @@ storiesOf('Filters', module)
       onAfterDrag={action('range change')}
       onCombineOptionToggle={action('combine mode change')}
       tierAccessLimit={1000}
-      isArrayField={true}
+      isArrayField
     />
   ))
   .add('SearchFilter', () => (
@@ -238,20 +238,26 @@ storiesOf('Filters', module)
       onSelect={action('checked')}
       onAfterDrag={action('range change')}
       tierAccessLimit={1000}
-      isSearchFilter={true}
-      onSearchFilterLoadOptions={(searchString, offset=0) => {
+      isSearchFilter
+      onSearchFilterLoadOptions={(searchString, offset = 0) => {
         const pageSize = 20;
         if (!searchString) {
           return {
-            options: guidOptions.slice(offset,offset+pageSize).map(option => ({value: option.text, label: option.text})),
+            options: guidOptions
+              .slice(offset, offset + pageSize)
+              .map(option => ({ value: option.text, label: option.text })),
             hasMore: guidOptions.length > offset + pageSize,
-          }
+          };
         }
-        const filteredOptions = guidOptions.filter(option => option.text.indexOf(searchString) !== -1);
+        const filteredOptions = guidOptions.filter(
+          option => option.text.indexOf(searchString) !== -1,
+        );
         return {
-          options: filteredOptions.slice(offset, offset+pageSize).map(option => ({value: option.text, label: option.text})),
-          hasMore: filteredOptions.length > offset + pageSize
-        }
+          options: filteredOptions
+            .slice(offset, offset + pageSize)
+            .map(option => ({ value: option.text, label: option.text })),
+          hasMore: filteredOptions.length > offset + pageSize,
+        };
       }}
     />
   ))


### PR DESCRIPTION
This PR fulfills: https://ctds-planx.atlassian.net/browse/PXP-7378

Add new chart type support `fullPie`, which will be rendered as a full pie chart

Screenshot from one of the stroybook examples
<img width="659" alt="Screen Shot 2021-01-13 at 5 50 37 PM" src="https://user-images.githubusercontent.com/2475897/104526439-032c7f00-55c8-11eb-8152-4f242a73d6ae.png">

Related PR: https://github.com/uc-cdis/data-portal/pull/784

### Improvements
- Add new chart type support `fullPie`, which will be rendered as a full pie chart

