### PR TITLE
(PXP-7718): fix/hideEmptyFilterSlider: if slider max is 0 hide

### DIFF
--- a/src/components/filters/FilterSection/index.jsx
+++ b/src/components/filters/FilterSection/index.jsx
@@ -481,6 +481,7 @@ class FilterSection extends React.Component {
                       inactive={lowerBound === undefined && upperBound === undefined}
                       count={option.count}
                       hideValue={hideValue}
+                      hideZero={this.props.hideZero}
                     />
                   );
                 }) : null

--- a/src/components/filters/RangeFilter/index.jsx
+++ b/src/components/filters/RangeFilter/index.jsx
@@ -145,6 +145,9 @@ class RangeFilter extends React.Component {
   }
 
   render() {
+    if (this.props.max === 0 && this.props.hideZero) {
+      return null;
+    }
     return (
       <div className='g3-range-filter'>
         { this.props.label
@@ -222,6 +225,7 @@ RangeFilter.propTypes = {
   hideValue: PropTypes.number,
   count: PropTypes.number,
   inactive: PropTypes.bool,
+  hideZero: PropTypes.bool,
 };
 
 RangeFilter.defaultProps = {
@@ -234,6 +238,7 @@ RangeFilter.defaultProps = {
   hideValue: -1,
   count: 0,
   inactive: false,
+  hideZero: true,
 };
 
 export default RangeFilter;

--- a/stories/filters.js
+++ b/stories/filters.js
@@ -210,6 +210,12 @@ storiesOf('Filters', module)
         max={2000000}
         rangeStep={10}
       />
+      <RangeFilter
+        label='Empty Ranger slider'
+        onAfterDrag={action('range change')}
+        min={0}
+        max={0}
+      />
     </div>
   ))
   .add('FilterSection', () => (


### PR DESCRIPTION
Jira Ticket: [PXP-7718](https://ctds-planx.atlassian.net/browse/PXP-7718)

### Bug Fixes / Feature
If slider is blank/unusable, do not display 
Implemented this.props.hideZero to work same as SingleSelectFilter, 
will need to set to true in data-portal currently defaults to false in guppy 