### PR TITLE
(COV-765): refactor/hideEmptyCharts: hide empty charts also add tests and storybook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gen3/ui-component",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "ISC",
       "dependencies": {
         "@storybook/addon-actions": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gen3/ui-component",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Basic UI component for gen3",
   "main": "index.js",
   "scripts": {

--- a/src/components/charts/SummaryChartGroup/SummaryChartGroup.test.jsx
+++ b/src/components/charts/SummaryChartGroup/SummaryChartGroup.test.jsx
@@ -28,6 +28,8 @@ describe('<SummaryChartGroup />', () => {
   const summaries = [
     { type: 'bar', title: 'Gender', data: chartData1 },
     { type: 'pie', title: 'Birth-Year', data: chartData },
+    { type: 'pie', title: 'Empty Pie', data: [] },
+    { type: 'bar', title: 'Empty Bar', data: [] },
     { type: 'pie', title: 'Species', data: chartData1 },
     { type: 'bar', title: 'Race', data: chartData2 },
     { type: 'bar', title: 'Virus', data: chartData },
@@ -43,10 +45,10 @@ describe('<SummaryChartGroup />', () => {
   });
 
   it('should render 3 bar charts', () => {
-    expect(charts.find(SummaryHorizontalBarChart).length).toBe(3);
+    expect(charts.find(SummaryHorizontalBarChart).length).toBe(4);
   });
 
   it('should render 2 pie charts', () => {
-    expect(charts.find(SummaryPieChart).length).toBe(2);
+    expect(charts.find(SummaryPieChart).length).toBe(3);
   });
 });

--- a/src/components/charts/SummaryChartGroup/SummaryChartGroup.test.jsx
+++ b/src/components/charts/SummaryChartGroup/SummaryChartGroup.test.jsx
@@ -28,6 +28,8 @@ describe('<SummaryChartGroup />', () => {
   const summaries = [
     { type: 'bar', title: 'Gender', data: chartData1 },
     { type: 'pie', title: 'Birth-Year', data: chartData },
+    { type: 'pie', title: 'Empty Pie', data: [] },
+    { type: 'bar', title: 'Empty Bar', data: [] },
     { type: 'pie', title: 'Species', data: chartData1 },
     { type: 'bar', title: 'Race', data: chartData2 },
     { type: 'bar', title: 'Virus', data: chartData },

--- a/src/components/charts/SummaryChartGroup/SummaryChartGroup.test.jsx
+++ b/src/components/charts/SummaryChartGroup/SummaryChartGroup.test.jsx
@@ -28,8 +28,6 @@ describe('<SummaryChartGroup />', () => {
   const summaries = [
     { type: 'bar', title: 'Gender', data: chartData1 },
     { type: 'pie', title: 'Birth-Year', data: chartData },
-    { type: 'pie', title: 'Empty Pie', data: [] },
-    { type: 'bar', title: 'Empty Bar', data: [] },
     { type: 'pie', title: 'Species', data: chartData1 },
     { type: 'bar', title: 'Race', data: chartData2 },
     { type: 'bar', title: 'Virus', data: chartData },

--- a/src/components/charts/SummaryChartGroup/index.jsx
+++ b/src/components/charts/SummaryChartGroup/index.jsx
@@ -61,10 +61,13 @@ class SummaryChartGroup extends Component {
 
   render() {
     const width = helper.parseParamWidth(this.props.width);
+
+    const filteredCharts = this.props.summaries.filter(chart => chart.data.length > 0);
+
     return (
       <div className='summary-chart-group' style={{ width }}>
         {
-          this.props.summaries.map((item, index) => (
+          filteredCharts.map((item, index) => (
             <div className='summary-chart-group__column' key={item.title}>
               {
                 index > 0 && <div className='summary-chart-group__column-left-border' />

--- a/src/components/charts/SummaryChartGroup/index.jsx
+++ b/src/components/charts/SummaryChartGroup/index.jsx
@@ -95,7 +95,7 @@ SummaryChartGroup.defaultProps = {
   useCustomizedColorMap: false,
   customizedColorMap: ['#3283c8'],
   maximumDisplayItem: 15,
-  chartEmptyMessage: 'Cannot render this chart because some fields don\'t apply',
+  chartEmptyMessage: 'This chart is empty',
 };
 
 export default SummaryChartGroup;

--- a/src/components/charts/SummaryChartGroup/index.jsx
+++ b/src/components/charts/SummaryChartGroup/index.jsx
@@ -18,7 +18,6 @@ class SummaryChartGroup extends Component {
           useCustomizedColorMap={this.props.useCustomizedColorMap}
           customizedColorMap={this.props.customizedColorMap}
           maximumDisplayItem={this.props.maximumDisplayItem}
-          chartIsEmpty={item.chartIsEmpty}
           chartEmptyMessage={this.props.chartEmptyMessage}
         />
         );
@@ -32,7 +31,6 @@ class SummaryChartGroup extends Component {
           useCustomizedColorMap={this.props.useCustomizedColorMap}
           customizedColorMap={this.props.customizedColorMap}
           maximumDisplayItem={this.props.maximumDisplayItem}
-          chartIsEmpty={item.chartIsEmpty}
           chartEmptyMessage={this.props.chartEmptyMessage}
           innerRadius={0}
         />
@@ -50,7 +48,6 @@ class SummaryChartGroup extends Component {
           useCustomizedColorMap={this.props.useCustomizedColorMap}
           customizedColorMap={this.props.customizedColorMap}
           maximumDisplayItem={this.props.maximumDisplayItem}
-          chartIsEmpty={item.chartIsEmpty}
           chartEmptyMessage={this.props.chartEmptyMessage}
         />
         );

--- a/src/components/charts/SummaryChartGroup/index.jsx
+++ b/src/components/charts/SummaryChartGroup/index.jsx
@@ -61,13 +61,10 @@ class SummaryChartGroup extends Component {
 
   render() {
     const width = helper.parseParamWidth(this.props.width);
-
-    const filteredCharts = this.props.summaries.filter(chart => chart.data.length > 0);
-
     return (
       <div className='summary-chart-group' style={{ width }}>
         {
-          filteredCharts.map((item, index) => (
+          this.props.summaries.map((item, index) => (
             <div className='summary-chart-group__column' key={item.title}>
               {
                 index > 0 && <div className='summary-chart-group__column-left-border' />

--- a/src/components/charts/SummaryHorizontalBarChart/index.jsx
+++ b/src/components/charts/SummaryHorizontalBarChart/index.jsx
@@ -34,7 +34,7 @@ class SummaryBarChart extends React.Component {
       this.props.percentageFixedPoint,
     );
     let chart = null;
-    if (this.props.chartIsEmpty) {
+    if (this.props.data.length === 0) {
       chart = (<EmptyContent message={this.props.chartEmptyMessage} />);
     } else if (helper.shouldHideChart(this.props.data, this.props.lockValue)) {
       chart = (<LockedContent lockMessage={this.props.lockMessage} />);
@@ -126,7 +126,6 @@ SummaryBarChart.propTypes = {
   lockValue: PropTypes.number, // if one of the value is equal to `lockValue`, lock the chart
   lockMessage: PropTypes.string,
   maximumDisplayItem: PropTypes.number,
-  chartIsEmpty: PropTypes.bool,
   chartEmptyMessage: PropTypes.string,
 };
 
@@ -139,7 +138,6 @@ SummaryBarChart.defaultProps = {
   lockValue: -1,
   lockMessage: 'This chart is hidden because it contains fewer than 1000 subjects',
   maximumDisplayItem: 15,
-  chartIsEmpty: false,
   chartEmptyMessage: 'Cannot render this chart because some fields don\'t apply',
 };
 

--- a/src/components/charts/SummaryHorizontalBarChart/index.jsx
+++ b/src/components/charts/SummaryHorizontalBarChart/index.jsx
@@ -138,7 +138,7 @@ SummaryBarChart.defaultProps = {
   lockValue: -1,
   lockMessage: 'This chart is hidden because it contains fewer than 1000 subjects',
   maximumDisplayItem: 15,
-  chartEmptyMessage: 'Cannot render this chart because some fields don\'t apply',
+  chartEmptyMessage: 'This chart is empty',
 };
 
 export default SummaryBarChart;

--- a/src/components/charts/SummaryPieChart/index.jsx
+++ b/src/components/charts/SummaryPieChart/index.jsx
@@ -39,7 +39,7 @@ class SummaryPieChart extends React.Component {
     );
     const dataKey = helper.getDataKey(this.props.showPercentage);
     let chart = null;
-    if (this.props.chartIsEmpty) {
+    if (this.props.data.length === 0) {
       chart = (<EmptyContent message={this.props.chartEmptyMessage} />);
     } else if (helper.shouldHideChart(this.props.data, this.props.lockValue)) {
       chart = <LockedContent lockMessage={this.props.lockMessage} />;
@@ -160,7 +160,6 @@ SummaryPieChart.propTypes = {
   useCustomizedColorMap: PropTypes.bool,
   customizedColorMap: PropTypes.arrayOf(PropTypes.string),
   maximumDisplayItem: PropTypes.number,
-  chartIsEmpty: PropTypes.bool,
   chartEmptyMessage: PropTypes.string,
 };
 
@@ -181,7 +180,6 @@ SummaryPieChart.defaultProps = {
   useCustomizedColorMap: false,
   customizedColorMap: ['#3283c8'],
   maximumDisplayItem: 15,
-  chartIsEmpty: false,
   chartEmptyMessage: 'Cannot render this chart because some fields don\'t apply',
 };
 

--- a/src/components/charts/SummaryPieChart/index.jsx
+++ b/src/components/charts/SummaryPieChart/index.jsx
@@ -180,7 +180,7 @@ SummaryPieChart.defaultProps = {
   useCustomizedColorMap: false,
   customizedColorMap: ['#3283c8'],
   maximumDisplayItem: 15,
-  chartEmptyMessage: 'Cannot render this chart because some fields don\'t apply',
+  chartEmptyMessage: 'This chart is empty',
 };
 
 export default SummaryPieChart;

--- a/stories/charts.js
+++ b/stories/charts.js
@@ -49,9 +49,6 @@ for (let i = 0; i < NUM_OPTIONS; i += 1) {
 const summaries = [
   { type: 'bar', title: 'Gender', data: genderData },
   { type: 'pie', title: 'Birth-Year', data: birthData },
-  { type: 'pie', title: 'Empty Pie', data: [] },
-  { type: 'bar', title: 'Empty Bar', data: [] },
-  { type: 'fullPie', title: 'Empty FullPie', data: [] },
   { type: 'fullPie', title: 'Species', data: speciesData },
   { type: 'bar', title: 'Race', data: raceData },
   { type: 'bar', title: 'Virus', data: virusData },

--- a/stories/charts.js
+++ b/stories/charts.js
@@ -49,6 +49,9 @@ for (let i = 0; i < NUM_OPTIONS; i += 1) {
 const summaries = [
   { type: 'bar', title: 'Gender', data: genderData },
   { type: 'pie', title: 'Birth-Year', data: birthData },
+  { type: 'pie', title: 'Empty Pie', data: [] },
+  { type: 'bar', title: 'Empty Bar', data: [] },
+  { type: 'fullPie', title: 'Empty FullPie', data: [] },
   { type: 'fullPie', title: 'Species', data: speciesData },
   { type: 'bar', title: 'Race', data: raceData },
   { type: 'bar', title: 'Virus', data: virusData },
@@ -80,7 +83,7 @@ const lockedSummaries = [
 
 const summariesWithOneEmpty = [
   {
-    type: 'bar', title: 'Gender', data: genderData, chartIsEmpty: true,
+    type: 'bar', title: 'Gender', data: [],
   },
   { type: 'pie', title: 'Birth-Year', data: lockedBirth },
   { type: 'pie', title: 'Species', data: speciesData },

--- a/stories/charts.js
+++ b/stories/charts.js
@@ -49,6 +49,9 @@ for (let i = 0; i < NUM_OPTIONS; i += 1) {
 const summaries = [
   { type: 'bar', title: 'Gender', data: genderData },
   { type: 'pie', title: 'Birth-Year', data: birthData },
+  { type: 'pie', title: 'Empty Pie', data: [] },
+  { type: 'bar', title: 'Empty Bar', data: [] },
+  { type: 'fullPie', title: 'Empty FullPie', data: [] },
   { type: 'fullPie', title: 'Species', data: speciesData },
   { type: 'bar', title: 'Race', data: raceData },
   { type: 'bar', title: 'Virus', data: virusData },


### PR DESCRIPTION
Jira Ticket: [COV-765](https://occ-data.atlassian.net/browse/COV-765)

### Breaking Changes 
- remove chartIsEmpty property from SummaryChartGroup component

### Improvements
- have empty chart message trigger when chart has no data
- add tests and storybook for new empty chart functionality 

