### PR TITLE
chore: use npm 8.5 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
 node_js:
   - '14'
 before_install:
-  - npm install -g npm@8
+  - npm install -g npm@8.5
 install:
   - npm ci
 script:


### PR DESCRIPTION
pin npm to 8.5 because npm 8.6 has introduced a bug in dependency resolution